### PR TITLE
Fix bug where it would recurse to external sites

### DIFF
--- a/google-sites.lua
+++ b/google-sites.lua
@@ -142,6 +142,14 @@ allowed = function(url, parenturl)
     return true
   end
 
+  -- At this point only Google Sites URLS should be in consideration
+  -- Technically, it is possible for this to recurse to other Google Sites;
+  --  but because these have a finite number of pages, even in the event
+  --  that this does happen, it will be of little consequence
+  if not string.match(url, '^https?://sites%.google%.com/') then
+    return false
+  end
+
   prev = nil
   for s in string.gmatch(url, "([a-zA-Z0-9%%%-_%.]+)") do
     if item_type == "site" and string.lower(s) == item_value_lower then

--- a/google-sites.lua
+++ b/google-sites.lua
@@ -142,20 +142,13 @@ allowed = function(url, parenturl)
     return true
   end
 
-  -- At this point only Google Sites URLS should be in consideration
-  -- Technically, it is possible for this to recurse to other Google Sites;
-  --  but because these have a finite number of pages, even in the event
-  --  that this does happen, it will be of little consequence
-  if not string.match(url, '^https?://sites%.google%.com/') then
-    return false
-  end
 
   prev = nil
   for s in string.gmatch(url, "([a-zA-Z0-9%%%-_%.]+)") do
-    if item_type == "site" and string.lower(s) == item_value_lower then
+    if item_type == "site" and string.lower(s) == item_value_lower and string.match(url, '^https?://sites%.google%.com/') then
       return true
     elseif item_type == "a" then
-      if prev and string.lower(prev .. "/" .. s) == item_value_lower then
+      if prev and string.lower(prev .. "/" .. s) == item_value_lower and string.match(url, '^https?://sites%.google%.com/') then
         return true
       end
       prev = s

--- a/pipeline.py
+++ b/pipeline.py
@@ -55,7 +55,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20201110.01'
+VERSION = '20210123.01'
 USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
 TRACKER_ID = 'google-sites'
 TRACKER_HOST = 'trackerproxy.archiveteam.org'

--- a/pipeline.py
+++ b/pipeline.py
@@ -55,7 +55,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20210123.01'
+VERSION = '20210123.02'
 USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
 TRACKER_ID = 'google-sites'
 TRACKER_HOST = 'trackerproxy.archiveteam.org'


### PR DESCRIPTION
Occured when they had a token in their URLs which was the same as the site name
E.g. site:homepiyo would recurse to a Twitter page of that same name