### PR TITLE
Fix Warrior support

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -42,7 +42,8 @@ WGET_AT = find_executable(
     [
         'GNU Wget 1.20.3-at.20200902.01',
         'GNU Wget 1.20.3-at.20200919.01',
-        'GNU Wget 1.20.3-at.20201030.01'
+        'GNU Wget 1.20.3-at.20201030.01',
+        'GNU Wget 1.20.3-at.20210212.02'
     ],
     [
          './wget-at',


### PR DESCRIPTION
This untested PR fixes Warrior support by declaring support for the version of `wget-at` that is currently included with the Warrior.