### PR TITLE
Update dictionary URL

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -165,7 +165,7 @@ class ZstdDict(object):
         if cls.data is not None and time.time() - cls.created < 1800:
             return cls.data
         response = requests.get(
-            'http://trackerproxy.archiveteam.org:25654/dictionary',
+            'https://legacy-api.arpa.li/dictionary',
             params={
                 'project': TRACKER_ID
             }


### PR DESCRIPTION
I haven't tested this, but https://legacy-api.arpa.li/dictionary?project=google-sites does exist and lets me download the dictionary.